### PR TITLE
[FIX] Flannel detection on K3s

### DIFF
--- a/kubefetch.go
+++ b/kubefetch.go
@@ -320,10 +320,10 @@ func getCNI(clientset *kubernetes.Clientset) string {
 					cniUsed = "Weave Net"
 				case strings.Contains(cniImage, "flannel"):
 					cniUsed = "Flannel"
-				default:
-					cniUsed = "unknown"
 				}
-			}
+			} else {
+				cniUsed = "unknown"
+		}
 		}
 	}
 


### PR DESCRIPTION
As containerImageContainsCNIName will always return false on a default K3s installation, the switch statement will never be run and we cannot rely on the default case