### PR TITLE
fix: replace deprecated Endpoints API with EndpointSlice

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.direnv
 .vscode
 /vendor
 kubefetch

--- a/kubefetch.go
+++ b/kubefetch.go
@@ -208,17 +208,19 @@ func getStorage(clientset *kubernetes.Clientset) string {
 
 func getKubernetesEndpointPort(clientset *kubernetes.Clientset) int {
 
-	endpoint, err := clientset.CoreV1().Endpoints("default").Get(context.TODO(), "kubernetes", v1.GetOptions{})
+	endpointSlices, err := clientset.DiscoveryV1().EndpointSlices("default").List(context.TODO(), v1.ListOptions{
+		LabelSelector: "kubernetes.io/service-name=kubernetes",
+	})
 	if err != nil {
 		panic(err.Error())
 	}
 
 	var portNumber int
 	// Accessing the ports exposed by the Endpoint
-	for _, subset := range endpoint.Subsets {
-		for _, port := range subset.Ports {
+	for _, endpointSlice := range endpointSlices.Items {
+		for _, port := range endpointSlice.Ports {
 			// Accessing port.Port
-			portNumber = int(port.Port)
+			portNumber = int(*port.Port)
 		}
 	}
 


### PR DESCRIPTION
This PR fixes a deprecation warning that appears when running against Kubernetes v1.33+:

```sh
go run ./kubefetch.go
W0726 16:14:19.136685   74201 warnings.go:70] v1 Endpoints is deprecated in v1.33+; use discovery.k8s.io/v1 EndpointSlice
```